### PR TITLE
feat: jest match pattern support full name with dot

### DIFF
--- a/packages/cli-plugin-test/src/index.ts
+++ b/packages/cli-plugin-test/src/index.ts
@@ -102,7 +102,7 @@ export class TestPlugin extends BasePlugin {
       pattern = process.env.TESTS.split(',');
     }
     if (!pattern.length) {
-      args.push(`/test/[^.]*\\.test\\.${isTs ? 'ts' : 'js'}$`);
+      args.push(`/test/.*\\.test\\.${isTs ? 'ts' : 'js'}$`);
     } else {
       const matchPattern = pattern.concat([
         '!test/fixtures',


### PR DESCRIPTION
original only support: foo.test.ts|js or foo-bar.test.ts|js
now support: foo.controller.test.ts|js