### PR TITLE
refactor: allAggregation support multiply events path

### DIFF
--- a/packages/faas-cli-plugin-package/src/index.ts
+++ b/packages/faas-cli-plugin-package/src/index.ts
@@ -736,21 +736,19 @@ export class PackagePlugin extends BasePlugin {
           }
         }
         allFuncNames = notMatchedFuncName;
-
-        handlers = matchedFuncName
-          .map((functionName: string) => {
-            const functions = this.core.service.functions;
-            const func = functions[functionName];
-            if (!func || !func.events) {
-              return;
-            }
-            const httpEventIndex = func.events.findIndex(
-              (event: any) => !!event.http
-            );
-            if (httpEventIndex === -1) {
-              return;
-            }
-            const httpEvent = func.events[httpEventIndex];
+        matchedFuncName.forEach((functionName: string) => {
+          const functions = this.core.service.functions;
+          const func = functions[functionName];
+          if (!func || !func.events) {
+            return;
+          }
+          const httpEventIndex = func.events.findIndex(
+            (event: any) => !!event.http
+          );
+          if (httpEventIndex === -1) {
+            return;
+          }
+          func.events.forEach(httpEvent => {
             if (!httpEvent || !httpEvent.http.path) {
               return;
             }
@@ -765,14 +763,15 @@ export class PackagePlugin extends BasePlugin {
               );
               delete this.core.service.functions[functionName];
             }
-            return {
+            handlers.push({
               ...func,
+              events: httpEvent,
               path: httpEvent.http.path,
-            };
-          })
-          .filter((func: any) => !!func);
+            });
+          });
+        });
       }
-
+      handlers = handlers.filter((func: any) => !!func);
       const allPaths = allAggred.map(aggre => aggre.path);
       let currentPath = commonPrefix(allPaths);
       currentPath =

--- a/packages/faas-cli-plugin-package/test/aggregation.test.ts
+++ b/packages/faas-cli-plugin-package/test/aggregation.test.ts
@@ -55,6 +55,8 @@ describe('/test/package.test.ts', () => {
       const allCode = readFileSync(resolve(buildDir, 'all.js')).toString();
       assert(/registerFunctionToIocByConfig/.test(allCode));
       assert(/"functionName": "fp"/.test(allCode));
+      assert(/"router": "\/multiply\/1"/.test(allCode));
+      assert(/"router": "\/multiply\/2"/.test(allCode));
     });
   });
 });

--- a/packages/faas-cli-plugin-package/test/fixtures/aggregation-fp/f.yml
+++ b/packages/faas-cli-plugin-package/test/fixtures/aggregation-fp/f.yml
@@ -58,6 +58,15 @@ functions:
       - http:
           method: get
           path: /normal/2
+  multiplyPath:
+    handler: multiplyPath.handler
+    events:
+      - http:
+          method: get
+          path: /multiply/1
+      - http:
+          method: get
+          path: /multiply/2
 
 custom:
   customDomain:


### PR DESCRIPTION
针对 events 多个 path 的情况考虑。需要遍历 events 对象。否则第二个path无法统计到生产环境访问会404。
通过本地 link的方式成功发布的线上应用地址为 [http://ssr-fc.com/detail/cbba934b14f747049187](http://ssr-fc.com/detail/cbba934b14f747049187)
yml文件如下
![image](https://user-images.githubusercontent.com/17424434/104464011-6a105f00-55ed-11eb-8661-0adeb94f90d0.png)
已解决 访问 404 的问题