### PR TITLE
fix: build param

### DIFF
--- a/packages/cli-plugin-build/src/index.ts
+++ b/packages/cli-plugin-build/src/index.ts
@@ -83,7 +83,7 @@ export class BuildPlugin extends BasePlugin {
     const { config } = resolveTsConfigFile(
       cwd,
       undefined,
-      this.options.tsConfig,
+      this.options.project,
       this.getStore('mwccHintConfig', 'global'),
       {
         compilerOptions: {


### PR DESCRIPTION
resolveTsConfigFile参数接收的应该是一个文件名，但是tsConfig被设计为传入一个JSON STRING。
为什么要设计两个 tsConfig和project两个参数来控制tsconfig，而且complie阶段为什么不从 getTsConfig 拿最后得到的值？