### PR TITLE
refactor: use createBootstrap replace createApp

### DIFF
--- a/packages/cli-plugin-dev/src/child.ts
+++ b/packages/cli-plugin-dev/src/child.ts
@@ -1,14 +1,24 @@
-import { createApp, close } from '@midwayjs/mock';
+import { createApp, close, createBootstrap } from '@midwayjs/mock';
 import { analysisDecorator } from './utils';
 const options = JSON.parse(process.argv[2]);
 let app;
+let bootstrapStarter;
 process.on('exit', async () => {
-  await close(app);
+  if (bootstrapStarter) {
+    await bootstrapStarter.close();
+  } else {
+    await close(app);
+  }
 });
 (async () => {
   let startSuccess = false;
   try {
-    app = await createApp(process.cwd(), options, options.framework);
+    if (options.entryFile) {
+      bootstrapStarter = await createBootstrap(options.entryFile);
+    } else {
+      app = await createApp(process.cwd(), options, options.framework);
+    }
+
     startSuccess = true;
   } catch (e) {
     console.log('');

--- a/packages/gateway-common-http/src/index.ts
+++ b/packages/gateway-common-http/src/index.ts
@@ -120,7 +120,7 @@ export class ExpressGateway {
             }
             if (res.send) {
               // express
-              res.send(data);
+              res.send(typeof data === 'number' ? data.toString() : data);
             } else {
               // connect
               if (typeof data === 'string' || Buffer.isBuffer(data)) {


### PR DESCRIPTION
处理适配 bootstrap 的一些问题

- [x] 1、调整 entryFile 下 createApp 为 createBootstrap
- [x] 2、处理下模拟的 http 网关，res.send 如果参数是数组，express 会默认当成状态码导致报错
- [ ] 3、bootstrap dev 的 console 输出被吞了，需要透出
- [ ] 4、bootstrap 下，需要展示实际的每个框架的启动信息，比如端口等等，要优化下