### PR TITLE
fix(dev-pack): fix illegal header error

### DIFF
--- a/packages/dev-pack/src/common.ts
+++ b/packages/dev-pack/src/common.ts
@@ -75,6 +75,17 @@ export async function invokeByDev(getDevCore) {
         })
         .join('&');
       delete params.query;
+      params.headers = Object.entries(params.headers).reduce(
+        (headers, [key, value]) => {
+          // Filter out HTTP/2 pseudo-headers
+          if (key.charAt(0) === ':') {
+            return headers;
+          }
+
+          return { ...headers, [key]: value };
+        },
+        {}
+      );
       params.redirect = 'manual';
       const result = await fetch(
         `http://127.0.0.1:${port}${params.path || '/'}${


### PR DESCRIPTION
When used with http2 server, the following error is thrown by node-fetch:
```
3:00:09 PM [vite] Internal server error: :method is not a legal HTTP header name
      at validateName (/***/node_modules/node-fetch/lib/index.js:677:9)
      at Headers.append (/***/node_modules/node-fetch/lib/index.js:835:3)
      at new Headers (/***/node_modules/node-fetch/lib/index.js:761:11)
      at new Request (/***/node_modules/node-fetch/lib/index.js:1231:19)
      at /***/node_modules/node-fetch/lib/index.js:1431:19
      at new Promise (<anonymous>)
      at fetch (/***/node_modules/node-fetch/lib/index.js:1429:9)
      at invoke (/***/node_modules/@midwayjs/serverless-dev-pack/dist/common.js:81:34)
      at ExpressGateway.transform (/***/node_modules/@midwayjs/gateway-common-http/dist/index.js:77:13)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This is caused by pseudo-headers in h2 (`:status`, `:method`, `:path`). Filtering out these headers could fix this problem.