### PR TITLE
feat: support plugin loading normally in monorepo project

### DIFF
--- a/packages/command-core/src/cli.ts
+++ b/packages/command-core/src/cli.ts
@@ -53,13 +53,12 @@ export class CoreBaseCLI {
     const packageJson = JSON.parse(readFileSync(packageJsonFile).toString());
     const deps = packageJson?.['midway-cli']?.plugins || [];
     this.core.debug('mw plugin', deps);
-    const currentNodeModules = join(cwd, 'node_modules');
     deps.forEach(dep => {
-      const npmPath = join(currentNodeModules, dep);
-      if (!existsSync(npmPath)) {
-        throw new Error(
-          `Auto load mw plugin error: '${dep}' not install in '${currentNodeModules}'`
-        );
+      let npmPath;
+      try {
+        npmPath = require.resolve(dep, { paths: [cwd] });
+      } catch (error) {
+        throw new Error(`Auto load mw plugin error: '${dep}' not install`);
       }
       try {
         const mod = require(npmPath);


### PR DESCRIPTION
I develop midway project in monorepo style , when running "npm run dev" script,   the terminal display some error info below:
![image](https://user-images.githubusercontent.com/10780785/201020928-ad61dcb9-da2d-466d-bd94-c4a36daa7acf.png)