### PR TITLE
feat: support watching files by glob patten in dev mode

### DIFF
--- a/packages/cli-plugin-dev/src/index.ts
+++ b/packages/cli-plugin-dev/src/index.ts
@@ -54,6 +54,12 @@ export class DevPlugin extends BasePlugin {
         watchFile: {
           usage: 'watch more file',
         },
+        watchFilePatten: {
+          usage: 'watch more files by glob patten',
+        },
+        unWatchFilePatten: {
+          usage: 'unwatch files by glob patten',
+        },
         watchExt: {
           usage: 'watch more extensions',
         },
@@ -371,6 +377,22 @@ export class DevPlugin extends BasePlugin {
           this.core.debug('other watch picomatch rule', file);
           watcher.add(file);
         }
+      });
+    }
+    if (this.options.watchFilePatten) {
+      const watchFilePattenList = this.options.watchFilePatten.split(',');
+      watchFilePattenList.forEach(file => {
+        const filePath = resolve(this.core.cwd, file);
+        this.core.debug('watch glob patten', filePath);
+        watcher.add(filePath);
+      });
+    }
+    if (this.options.unWatchFilePatten) {
+      const unWatchFilePattenList = this.options.unWatchFilePatten.split(',');
+      unWatchFilePattenList.forEach(file => {
+        const filePath = resolve(this.core.cwd, file);
+        this.core.debug('unwatch glob patten', filePath);
+        watcher.unwatch(filePath);
       });
     }
     watcher.on('all', (event, path) => {

--- a/packages/cli-plugin-dev/test/fixtures/base-app/default-data-cache
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/default-data-cache
@@ -1,0 +1,3 @@
+module.exports = {
+  watchData: "watch2",
+}

--- a/packages/cli-plugin-dev/test/fixtures/base-app/default-data.js
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/default-data.js
@@ -1,0 +1,3 @@
+module.exports = {
+  watchData: "watch1",
+}

--- a/packages/cli-plugin-dev/test/fixtures/base-app/package.json
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ali-demo",
   "dependencies": {
+    "@midwayjs/mock": "^2.14.6",
     "@midwayjs/web": "2"
   }
 }

--- a/packages/cli-plugin-dev/test/fixtures/base-app/src/config/config.default.ts
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/src/config/config.default.ts
@@ -1,5 +1,5 @@
 'use strict';
-
+import { watchData } from "../../default-data";
 export const keys = 'key';
 
 export const hello = {
@@ -7,3 +7,5 @@ export const hello = {
   b: 2,
   d: [1, 2, 3],
 };
+
+export const watchKey = watchData;

--- a/packages/cli-plugin-dev/test/fixtures/base-app/src/config/config.unittest.ts
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/src/config/config.unittest.ts
@@ -1,5 +1,8 @@
+import { unWatchData } from '../../unittest-data';
 
 exports.hello = {
   b: 4,
   c: 3,
 };
+
+export const unWatchKey = unWatchData;

--- a/packages/cli-plugin-dev/test/fixtures/base-app/src/controller/api.cache
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/src/controller/api.cache
@@ -8,6 +8,7 @@ import {
   Body,
   HttpCode,
   Redirect,
+  Config
 } from '@midwayjs/decorator';
 import { UserService } from '../service/user';
 
@@ -20,6 +21,12 @@ export class APIController {
   @Inject()
   userService: UserService;
 
+  @Config()
+  watchKey: string;
+
+  @Config()
+  unWatchKey: string;
+
   @Post()
   async postData(@Body('bbbbb') bbbb) {
     return 'data';
@@ -29,6 +36,18 @@ export class APIController {
   @HttpCode(201)
   async home(@Query('name') name: string) {
     return 'hello world,' + name;
+  }
+
+  @Get('/testWatch')
+  @HttpCode(201)
+  async testWatch() {
+    return this.watchKey;
+  }
+
+  @Get('/tesUnWatch')
+  @HttpCode(201)
+  async tesUnWatch() {
+    return this.unWatchKey;
   }
 
   @Get('/login')

--- a/packages/cli-plugin-dev/test/fixtures/base-app/src/controller/api.ts
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/src/controller/api.ts
@@ -8,6 +8,7 @@ import {
   Body,
   HttpCode,
   Redirect,
+  Config
 } from '@midwayjs/decorator';
 import { UserService } from '../service/user';
 
@@ -20,6 +21,12 @@ export class APIController {
   @Inject()
   userService: UserService;
 
+  @Config()
+  watchKey: string;
+
+  @Config()
+  unWatchKey: string;
+
   @Post()
   async postData(@Body('bbbbb') bbbb) {
     return 'data';
@@ -29,6 +36,18 @@ export class APIController {
   @HttpCode(201)
   async home(@Query('name') name: string) {
     return 'hello world,' + name;
+  }
+
+  @Get('/testWatch')
+  @HttpCode(201)
+  async testWatch() {
+    return this.watchKey;
+  }
+
+  @Get('/tesUnWatch')
+  @HttpCode(201)
+  async tesUnWatch() {
+    return this.unWatchKey;
   }
 
   @Get('/login')

--- a/packages/cli-plugin-dev/test/fixtures/base-app/src/controller/api2.cache
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/src/controller/api2.cache
@@ -8,6 +8,7 @@ import {
   Body,
   HttpCode,
   Redirect,
+  Config
 } from '@midwayjs/decorator';
 import { UserService } from '../service/user';
 
@@ -20,6 +21,12 @@ export class APIController {
   @Inject()
   userService: UserService;
 
+  @Config()
+  watchKey: string;
+
+  @Config()
+  unWatchKey: string;
+
   @Post()
   async postData(@Body('bbbbb') bbbb) {
     return 'data';
@@ -29,6 +36,18 @@ export class APIController {
   @HttpCode(201)
   async home(@Query('name') name: string) {
     return 'hello world2,' + name;
+  }
+
+  @Get('/testWatch')
+  @HttpCode(201)
+  async testWatch() {
+    return this.watchKey;
+  }
+
+  @Get('/tesUnWatch')
+  @HttpCode(201)
+  async tesUnWatch() {
+    return this.unWatchKey;
   }
 
   @Get('/login')

--- a/packages/cli-plugin-dev/test/fixtures/base-app/unittest-data-cache
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/unittest-data-cache
@@ -1,0 +1,3 @@
+module.exports = {
+  unWatchData: "unwatch4",
+}

--- a/packages/cli-plugin-dev/test/fixtures/base-app/unittest-data.js
+++ b/packages/cli-plugin-dev/test/fixtures/base-app/unittest-data.js
@@ -1,0 +1,3 @@
+module.exports = {
+  unWatchData: "unwatch3",
+}

--- a/packages/cli-plugin-dev/test/fixtures/error-app/package.json
+++ b/packages/cli-plugin-dev/test/fixtures/error-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ali-demo",
   "dependencies": {
+    "@midwayjs/mock": "^2.14.6",
     "@midwayjs/web": "2"
   }
 }

--- a/packages/cli-plugin-dev/test/index.test.ts
+++ b/packages/cli-plugin-dev/test/index.test.ts
@@ -9,6 +9,12 @@ const cwd = join(__dirname, 'fixtures/base-app');
 const api = join(cwd, 'src/controller/api.ts');
 const api1 = join(cwd, 'src/controller/api.cache');
 const api2 = join(cwd, 'src/controller/api2.cache');
+
+const dConfig = join(cwd, 'default-data.js');
+const dcConfig = join(cwd, 'default-data-cache');
+const uConfig = join(cwd, 'unittest-data.js');
+const ucConfig = join(cwd, 'unittest-data-cache');
+
 describe('test/index.test.ts', () => {
   it('dev', async () => {
     const dist = join(cwd, 'dist');
@@ -18,6 +24,9 @@ describe('test/index.test.ts', () => {
     const { close, port } = await run(cwd, {
       fast: true,
       watchFile: 'package.json',
+      watchFilePatten: './*-data.js',
+      unWatchFilePatten: './unittest*.js',
+      watchExt: '.ts,.yml,.json,.js',
     });
     if (existsSync(api)) {
       await remove(api);
@@ -34,6 +43,21 @@ describe('test/index.test.ts', () => {
     const response2 = await fetch(`http://127.0.0.1:${port}/?name=midway`);
     const body2 = await response2.text();
     assert(body2 === 'hello world2,midway');
+
+    await remove(dConfig);
+    await copy(dcConfig, dConfig);
+    await wait();
+    const response3 = await fetch(`http://127.0.0.1:${port}/testWatch`);
+    const body3 = await response3.text();
+    assert(body3 === 'watch2');
+
+    await remove(uConfig);
+    await copy(ucConfig, uConfig);
+    await wait();
+    const response4 = await fetch(`http://127.0.0.1:${port}/tesUnWatch`);
+    const body4 = await response4.text();
+    assert(body4 === 'unwatch3');
+
     await wait();
     await close();
   });


### PR DESCRIPTION
When I develop midway project with monorepo style in dev mode, If I want to debug the components code in packages folder, I must enumerate all the directories through the watchFile parameter. When these directories may change at any time, this is not an elegant scheme. However, if I only list the packages directory, all the files (include files in logs and run folders) in the midway framework will also be watched, which will cause the dev server to restart cyclically.   So I suggest add unWatchFilePatten and watchFilePatten parameters to solve this problem