### PR TITLE
fix: tsconfig 引用路径解析问题

### DIFF
--- a/packages/cli-plugin-build/src/index.ts
+++ b/packages/cli-plugin-build/src/index.ts
@@ -189,7 +189,7 @@ export class BuildPlugin extends BasePlugin {
         return this.getCompilerOptions(
           require(join(projectDir, tsConfig.extends)),
           optionKeyPath,
-          { projectDir }
+          dirname(join(projectDir, tsConfig.extends))
         );
       }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10780785/212005358-3102c027-e8e9-4fbb-8130-8b9cab8114a6.png)
tsconfig 使用 extends 字段引用其他文件的时候，会导致 projectDir变成了一个object，join(projectDir, tsConfig.extends)的时候就会报错