### PR TITLE
fix(command-core): fix path process within formatTsError() and add types

### DIFF
--- a/packages/command-core/package.json
+++ b/packages/command-core/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "lint": "../../node_modules/.bin/eslint .",
     "build": "tsc --build",
-    "test": "../../node_modules/.bin/jest ./test/cli.test.ts",
+    "test": "../../node_modules/.bin/jest ./test/cli.test.ts ./test/formatTsError.test.ts",
     "cov": "cross-env ../../node_modules/.bin/jest --coverage",
     "cov-win": "npm run cov",
     "ci-test-only": "TESTS=test/lib/cmd/cov.test.js npm run test-local",

--- a/packages/command-core/src/utils/compileTypeScript.ts
+++ b/packages/command-core/src/utils/compileTypeScript.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'fs-extra';
 import { join, relative } from 'path';
 import {
-  DiagnosticRelatedInformation,
   DiagnosticMessageChain,
+  DiagnosticRelatedInformation,
   // eslint-disable-next-line node/no-unpublished-import
 } from 'typescript';
 
@@ -79,7 +79,7 @@ export const compileTypeScript = async (options: {
   };
 };
 
-const formatTsError = (
+export const formatTsError = (
   baseDir: string,
   error: DiagnosticRelatedInformation
 ): { message: string; path: string } => {

--- a/packages/command-core/src/utils/compileTypeScript.ts
+++ b/packages/command-core/src/utils/compileTypeScript.ts
@@ -83,7 +83,7 @@ export const formatTsError = (
   baseDir: string,
   error: DiagnosticRelatedInformation
 ): { message: string; path: string } => {
-  if (!error || !error.messageText) {
+  if (!error.messageText) {
     return { message: '', path: '' };
   }
   const message = pickMessageTextFromDiagnosticMessageChain(error.messageText);

--- a/packages/command-core/test/formatTsError.test.ts
+++ b/packages/command-core/test/formatTsError.test.ts
@@ -1,0 +1,136 @@
+import { relative } from 'path';
+import * as assert from 'assert';
+
+import {
+  DiagnosticMessageChain,
+  DiagnosticRelatedInformation,
+  // eslint-disable-next-line node/no-unpublished-import
+} from 'typescript';
+
+import { formatTsError } from '../src/utils/compileTypeScript';
+
+const filename = relative(process.cwd(), __filename).replace(/\\/gu, '/');
+
+describe(filename, () => {
+  const baseDir = process.cwd();
+  const name = 'index.test.ts';
+  const fileText = `import assert from 'node:assert/strict';
+import { relative } from 'node:path';
+void assert;
+void relative;`;
+  const expectPath = `${name}:4:14`;
+
+  it('messageText is string', async () => {
+    const messageText = 'messageText is string';
+
+    const info = {
+      category: 1,
+      code: 2345,
+      file: {
+        text: fileText,
+        fileName: `./${name}`,
+      },
+      start: 1000,
+      length: 1000,
+      messageText,
+    } as DiagnosticRelatedInformation;
+
+    const ret = formatTsError(baseDir, info);
+    assert(ret);
+    assert(ret.message === messageText);
+    assert(ret.path === expectPath);
+  });
+
+  it('messageText is DiagnosticMessageChain', async () => {
+    const text1 = 'messageText is DiagnosticMessageChain';
+    const messageText: DiagnosticMessageChain = {
+      messageText: text1,
+      category: 1,
+      code: 2,
+    };
+
+    const info = {
+      category: 1,
+      code: 2345,
+      file: {
+        text: fileText,
+        fileName: `./${name}`,
+      },
+      start: 1000,
+      length: 1000,
+      messageText,
+    } as DiagnosticRelatedInformation;
+
+    const ret = formatTsError(baseDir, info);
+    assert(ret);
+    assert(ret.message === text1);
+    assert(ret.path === expectPath);
+  });
+
+  it('messageText is DiagnosticMessageChain and empty next', async () => {
+    const text1 = 'messageText is DiagnosticMessageChain';
+    const messageText: DiagnosticMessageChain = {
+      messageText: text1,
+      category: 1,
+      code: 2,
+      next: [],
+    };
+
+    const info = {
+      category: 1,
+      code: 2345,
+      file: {
+        text: fileText,
+        fileName: `./${name}`,
+      },
+      start: 1000,
+      length: 1000,
+      messageText,
+    } as DiagnosticRelatedInformation;
+
+    const ret = formatTsError(baseDir, info);
+    assert(ret);
+    assert(ret.message === text1);
+    assert(ret.path === expectPath);
+  });
+
+  it('messageText is DiagnosticMessageChain and next', async () => {
+    const text1 = 'messageText is DiagnosticMessageChain';
+    const chainMessageText = 'messageText is DiagnosticMessageChain next';
+
+    const chain: DiagnosticMessageChain = {
+      messageText: chainMessageText,
+      category: 1,
+      code: 2,
+      next: [],
+    };
+    const messageText: DiagnosticMessageChain = {
+      messageText: text1,
+      category: 1,
+      code: 2,
+      next: [chain],
+    };
+
+    const info = {
+      category: 1,
+      code: 2345,
+      file: {
+        text: fileText,
+        fileName: `./${name}`,
+      },
+      start: 1000,
+      length: 1000,
+      messageText,
+    } as DiagnosticRelatedInformation;
+    const ret = formatTsError(baseDir, info);
+
+    assert(ret);
+    assert(ret.message);
+    assert(ret.path === expectPath);
+    const messageArr = ret.message.split('\n');
+    assert(Array.isArray(messageArr));
+    const [message1, message2] = messageArr;
+    assert(message1 === text1);
+    assert(message2.trim() === chainMessageText);
+  });
+});

--- a/packages/command-core/test/formatTsError.test.ts
+++ b/packages/command-core/test/formatTsError.test.ts
@@ -41,6 +41,27 @@ void relative;`;
     assert(ret.path === expectPath);
   });
 
+  it('messageText is empty', async () => {
+    const messageText = '';
+
+    const info = {
+      category: 1,
+      code: 2345,
+      file: {
+        text: fileText,
+        fileName: `./${name}`,
+      },
+      start: 1000,
+      length: 1000,
+      messageText,
+    } as DiagnosticRelatedInformation;
+
+    const ret = formatTsError(baseDir, info);
+    assert(ret);
+    assert(ret.message === messageText);
+    assert(ret.path === '');
+  });
+
   it('messageText is DiagnosticMessageChain', async () => {
     const text1 = 'messageText is DiagnosticMessageChain';
     const messageText: DiagnosticMessageChain = {


### PR DESCRIPTION
- 函数 `formatTsError` 增加类型声明
- 正确处理 messageText （ `string | DiagnosticMessageChain` ）值
- 当 messageText  为对象时正确处理返回值 `path` （修复之前错误处理为空）